### PR TITLE
✨ feat(theme): add FossThemeSpec and FossThemeData.retheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## Unreleased
+
+A quality pass over every component: accessibility, visual fidelity, touch
+targets, and golden coverage. No new components, plus one additive theming API
+for one-call rebrands.
+
+### Added
+
+* `FossThemeData.retheme` layers a compact `FossThemeSpec` over a base theme:
+  enumerated color roles, plus single seeds for radius, spacing, shadow tint, and
+  font family. `FossRadii.fromBase` derives the radius scale from one value.
+
+### Improved
+
+* Accessibility across the set. The progress bar exposes its role and numeric
+  range. Radio groups get arrow-key roving focus and a group role. The spinner
+  stops under reduced motion and announces once on appear. Toasts announce
+  errors assertively and hold open while pressed. Text fields expose the hint as
+  an accessible hint and drop focus on an outside tap.
+* Touch targets sized for the finger. A standalone checkbox and an icon-only
+  button floor to a full target, while grouped rows hug their content so a stack
+  keeps even spacing.
+* Fidelity fixes. Softer resting shadows on the switch, tabs, tooltip, and
+  slider. Corrected padding on the badge, tabs, and text field. Card content
+  inherits the card foreground, and every form error caption shares one color.
+* Toasts swipe to dismiss in any direction, and the drawer drags without
+  rebuilding its panel.
+
+### Fixed
+
+* A toast queued behind the visible cap no longer expires before it is seen; its
+  timer pauses until it surfaces.
+
 ## 0.1.0-beta.2
 
 Consolidation and polish. No new components; the public API is unchanged.

--- a/lib/src/theme/foss_theme.dart
+++ b/lib/src/theme/foss_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' show Theme, ThemeData, ThemeExtension;
 import 'package:flutter/widgets.dart';
 import 'package:fossui/src/theme/colors/foss_colors.dart';
+import 'package:fossui/src/theme/foss_theme_spec.dart';
 import 'package:fossui/src/theme/motion/foss_motion.dart';
 import 'package:fossui/src/theme/radii/foss_radii.dart';
 import 'package:fossui/src/theme/shadows/foss_shadows.dart';
@@ -67,6 +68,60 @@ class FossThemeData extends ThemeExtension<FossThemeData> {
   /// Animation durations.
   final FossMotion motion;
 
+  /// Layers [spec] over this theme, returning a rethemed copy. Each unset spec
+  /// field keeps this theme's value; colors pass through enumerated, while
+  /// radius, spacing, shadow color, and font family seed their scales. Start
+  /// from [light] or [dark].
+  ///
+  /// ```dart
+  /// final theme = FossThemeData.light.retheme(
+  ///   const FossThemeSpec(primary: Color(0xFF51F0A8), radius: 22),
+  /// );
+  /// ```
+  FossThemeData retheme(FossThemeSpec spec) {
+    final radius = spec.radius;
+    final unit = spec.spacing;
+    final shadowColor = spec.shadowColor;
+    final fontFamily = spec.fontFamily;
+    return FossThemeData(
+      colors: colors.copyWith(
+        background: spec.background,
+        foreground: spec.foreground,
+        card: spec.card,
+        cardForeground: spec.cardForeground,
+        popover: spec.popover,
+        popoverForeground: spec.popoverForeground,
+        primary: spec.primary,
+        primaryForeground: spec.primaryForeground,
+        secondary: spec.secondary,
+        secondaryForeground: spec.secondaryForeground,
+        muted: spec.muted,
+        mutedForeground: spec.mutedForeground,
+        accent: spec.accent,
+        accentForeground: spec.accentForeground,
+        destructive: spec.destructive,
+        destructiveForeground: spec.destructiveForeground,
+        destructiveForegroundOn: spec.destructiveForegroundOn,
+        info: spec.info,
+        infoForeground: spec.infoForeground,
+        success: spec.success,
+        successForeground: spec.successForeground,
+        warning: spec.warning,
+        warningForeground: spec.warningForeground,
+        border: spec.border,
+        input: spec.input,
+        ring: spec.ring,
+      ),
+      radii: radius == null ? radii : FossRadii.fromBase(radius),
+      spacing: unit == null ? spacing : FossSpacing(unit: unit),
+      typography: fontFamily == null
+          ? typography
+          : _reFamily(typography, fontFamily),
+      shadows: shadowColor == null ? shadows : _reTint(shadows, shadowColor),
+      motion: motion,
+    );
+  }
+
   @override
   FossThemeData copyWith({
     FossColors? colors,
@@ -122,6 +177,35 @@ class FossThemeData extends ThemeExtension<FossThemeData> {
   int get hashCode =>
       Object.hash(colors, radii, spacing, typography, shadows, motion);
 }
+
+/// Rebuilds every type step on [family], preserving size, height, and spacing.
+FossTypography _reFamily(FossTypography t, String family) => FossTypography(
+  xs: t.xs.copyWith(fontFamily: family),
+  sm: t.sm.copyWith(fontFamily: family),
+  base: t.base.copyWith(fontFamily: family),
+  lg: t.lg.copyWith(fontFamily: family),
+  xl: t.xl.copyWith(fontFamily: family),
+  xl2: t.xl2.copyWith(fontFamily: family),
+);
+
+/// Re-tints every shadow layer to [color], keeping each layer's alpha and
+/// geometry.
+FossShadows _reTint(FossShadows s, Color color) => FossShadows(
+  xs: _tint(s.xs, color),
+  sm: _tint(s.sm, color),
+  md: _tint(s.md, color),
+  lg: _tint(s.lg, color),
+);
+
+List<BoxShadow> _tint(List<BoxShadow> layers, Color color) => [
+  for (final layer in layers)
+    BoxShadow(
+      color: color.withValues(alpha: layer.color.a),
+      offset: layer.offset,
+      blurRadius: layer.blurRadius,
+      spreadRadius: layer.spreadRadius,
+    ),
+];
 
 /// Provides a [FossThemeData] to its subtree for non-Material apps. Material
 /// apps can instead register the theme in `ThemeData.extensions`; either way

--- a/lib/src/theme/foss_theme_spec.dart
+++ b/lib/src/theme/foss_theme_spec.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/widgets.dart';
+import 'package:fossui/src/theme/foss_theme.dart';
+
+/// A compact override layer for retheming a [FossThemeData] in one call.
+///
+/// Every field is optional; an unset field keeps the base theme's value. Colors
+/// pass through enumerated (one role per field, no auto-contrast). The scales
+/// are single seeds: [radius] derives the radius steps, [spacing] sets the
+/// spacing unit, [shadowColor] re-tints every shadow layer, and [fontFamily]
+/// applies across every type step. Layer it with [FossThemeData.retheme].
+///
+/// ```dart
+/// final theme = FossThemeData.light.retheme(
+///   const FossThemeSpec(
+///     primary: Color(0xFF51F0A8),
+///     primaryForeground: Color(0xFF000000),
+///     ring: Color(0xFF51F0A8),
+///     radius: 22,
+///     fontFamily: 'Plus Jakarta Sans',
+///   ),
+/// );
+/// ```
+///
+/// For a light and dark pair, layer one spec over each base and give each its
+/// own color values (dark usually wants brighter shades):
+///
+/// ```dart
+/// MaterialApp(
+///   theme: FossThemeData.light.retheme(
+///     const FossThemeSpec(primary: Color(0xFF16A34A), radius: 22),
+///   ).toThemeData(),
+///   darkTheme: FossThemeData.dark.retheme(
+///     const FossThemeSpec(primary: Color(0xFF51F0A8), radius: 22),
+///   ).toThemeData(),
+/// );
+/// ```
+@immutable
+class FossThemeSpec {
+  /// Creates an override layer; every field defaults to null (keep the base).
+  const FossThemeSpec({
+    this.background,
+    this.foreground,
+    this.card,
+    this.cardForeground,
+    this.popover,
+    this.popoverForeground,
+    this.primary,
+    this.primaryForeground,
+    this.secondary,
+    this.secondaryForeground,
+    this.muted,
+    this.mutedForeground,
+    this.accent,
+    this.accentForeground,
+    this.destructive,
+    this.destructiveForeground,
+    this.destructiveForegroundOn,
+    this.info,
+    this.infoForeground,
+    this.success,
+    this.successForeground,
+    this.warning,
+    this.warningForeground,
+    this.border,
+    this.input,
+    this.ring,
+    this.radius,
+    this.spacing,
+    this.shadowColor,
+    this.fontFamily,
+  });
+
+  /// App background override.
+  final Color? background;
+
+  /// Default text/icon color override.
+  final Color? foreground;
+
+  /// Card surface override.
+  final Color? card;
+
+  /// Text/icon color on the card override.
+  final Color? cardForeground;
+
+  /// Popover and menu surface override.
+  final Color? popover;
+
+  /// Text/icon color on the popover override.
+  final Color? popoverForeground;
+
+  /// Primary action color override.
+  final Color? primary;
+
+  /// Text/icon color on the primary color override.
+  final Color? primaryForeground;
+
+  /// Secondary surface override.
+  final Color? secondary;
+
+  /// Text/icon color on the secondary surface override.
+  final Color? secondaryForeground;
+
+  /// Muted surface override.
+  final Color? muted;
+
+  /// Low-emphasis text color override.
+  final Color? mutedForeground;
+
+  /// Accent surface override.
+  final Color? accent;
+
+  /// Text/icon color on the accent surface override.
+  final Color? accentForeground;
+
+  /// Destructive action color override.
+  final Color? destructive;
+
+  /// Text/icon color paired with the destructive color override.
+  final Color? destructiveForeground;
+
+  /// Text/icon color on a solid destructive fill override.
+  final Color? destructiveForegroundOn;
+
+  /// Informational accent override.
+  final Color? info;
+
+  /// Text/icon color paired with the info color override.
+  final Color? infoForeground;
+
+  /// Success accent override.
+  final Color? success;
+
+  /// Text/icon color paired with the success color override.
+  final Color? successForeground;
+
+  /// Warning accent override.
+  final Color? warning;
+
+  /// Text/icon color paired with the warning color override.
+  final Color? warningForeground;
+
+  /// Default border/divider color override.
+  final Color? border;
+
+  /// Form-control border color override.
+  final Color? input;
+
+  /// Focus ring color override.
+  final Color? ring;
+
+  /// Radius base in logical pixels; derives the full radius scale.
+  final double? radius;
+
+  /// Spacing unit in logical pixels; every step is `unit * n`.
+  final double? spacing;
+
+  /// Re-tints every shadow layer, keeping each layer's alpha and geometry.
+  final Color? shadowColor;
+
+  /// Font family applied across every type step.
+  final String? fontFamily;
+}

--- a/lib/src/theme/radii/foss_radii.dart
+++ b/lib/src/theme/radii/foss_radii.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart' show ThemeExtension;
 import 'package:fossui/src/theme/lerp_encoders.dart';
 import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
@@ -22,6 +24,24 @@ class FossRadii extends ThemeExtension<FossRadii> with _$FossRadiiTailorMixin {
     required this.xl,
     required this.xl2,
   });
+
+  /// Derives the full scale from a single [base] (the `lg` step). Steps offset
+  /// from it (sm -4, md -2, lg +0, xl +4, xl2 +6), each clamped at 0, so
+  /// `fromBase(10)` reproduces [standard].
+  ///
+  /// ```dart
+  /// final r = FossRadii.fromBase(22); // rounder corners across the app
+  /// ```
+  factory FossRadii.fromBase(double base) {
+    double step(double delta) => math.max(0, base + delta);
+    return FossRadii(
+      sm: step(-4),
+      md: step(-2),
+      lg: step(0),
+      xl: step(4),
+      xl2: step(6),
+    );
+  }
 
   /// Small corners (6 px): controls, chips.
   @override

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -7,6 +7,7 @@
 
 export 'colors/foss_colors.dart';
 export 'foss_theme.dart';
+export 'foss_theme_spec.dart';
 export 'motion/foss_motion.dart';
 export 'radii/foss_radii.dart';
 export 'shadows/foss_shadows.dart';

--- a/test/theme/foss_theme_spec_test.dart
+++ b/test/theme/foss_theme_spec_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fossui/fossui.dart';
+
+void main() {
+  group('FossThemeData.retheme', () {
+    test('an unset field keeps the base value', () {
+      const brand = Color(0xFF51F0A8);
+      final theme = FossThemeData.light.retheme(
+        const FossThemeSpec(primary: brand),
+      );
+      expect(theme.colors.primary, brand);
+      expect(theme.colors.secondary, FossColors.light.secondary);
+      expect(theme.radii, FossThemeData.light.radii);
+      expect(theme.spacing, FossThemeData.light.spacing);
+      expect(theme.typography, FossThemeData.light.typography);
+    });
+
+    test('empty spec round-trips to the light base', () {
+      expect(
+        FossThemeData.light.retheme(const FossThemeSpec()),
+        FossThemeData.light,
+      );
+    });
+
+    test('base swap starts from the dark set', () {
+      final theme = FossThemeData.dark.retheme(
+        const FossThemeSpec(primary: Color(0xFF51F0A8)),
+      );
+      expect(theme.colors.background, FossColors.dark.background);
+      expect(theme.colors.secondary, FossColors.dark.secondary);
+    });
+
+    test('every color role forwards independently', () {
+      // Distinct value per role: proves the spec covers the full set and each
+      // maps to its own field with no cross-talk.
+      const spec = FossThemeSpec(
+        background: Color(0xFF000001),
+        foreground: Color(0xFF000002),
+        card: Color(0xFF000003),
+        cardForeground: Color(0xFF000004),
+        popover: Color(0xFF000005),
+        popoverForeground: Color(0xFF000006),
+        primary: Color(0xFF000007),
+        primaryForeground: Color(0xFF000008),
+        secondary: Color(0xFF000009),
+        secondaryForeground: Color(0xFF00000A),
+        muted: Color(0xFF00000B),
+        mutedForeground: Color(0xFF00000C),
+        accent: Color(0xFF00000D),
+        accentForeground: Color(0xFF00000E),
+        destructive: Color(0xFF00000F),
+        destructiveForeground: Color(0xFF000010),
+        destructiveForegroundOn: Color(0xFF000011),
+        info: Color(0xFF000012),
+        infoForeground: Color(0xFF000013),
+        success: Color(0xFF000014),
+        successForeground: Color(0xFF000015),
+        warning: Color(0xFF000016),
+        warningForeground: Color(0xFF000017),
+        border: Color(0xFF000018),
+        input: Color(0xFF000019),
+        ring: Color(0xFF00001A),
+      );
+      final c = FossThemeData.light.retheme(spec).colors;
+      expect(c.background, const Color(0xFF000001));
+      expect(c.foreground, const Color(0xFF000002));
+      expect(c.card, const Color(0xFF000003));
+      expect(c.cardForeground, const Color(0xFF000004));
+      expect(c.popover, const Color(0xFF000005));
+      expect(c.popoverForeground, const Color(0xFF000006));
+      expect(c.primary, const Color(0xFF000007));
+      expect(c.primaryForeground, const Color(0xFF000008));
+      expect(c.secondary, const Color(0xFF000009));
+      expect(c.secondaryForeground, const Color(0xFF00000A));
+      expect(c.muted, const Color(0xFF00000B));
+      expect(c.mutedForeground, const Color(0xFF00000C));
+      expect(c.accent, const Color(0xFF00000D));
+      expect(c.accentForeground, const Color(0xFF00000E));
+      expect(c.destructive, const Color(0xFF00000F));
+      expect(c.destructiveForeground, const Color(0xFF000010));
+      expect(c.destructiveForegroundOn, const Color(0xFF000011));
+      expect(c.info, const Color(0xFF000012));
+      expect(c.infoForeground, const Color(0xFF000013));
+      expect(c.success, const Color(0xFF000014));
+      expect(c.successForeground, const Color(0xFF000015));
+      expect(c.warning, const Color(0xFF000016));
+      expect(c.warningForeground, const Color(0xFF000017));
+      expect(c.border, const Color(0xFF000018));
+      expect(c.input, const Color(0xFF000019));
+      expect(c.ring, const Color(0xFF00001A));
+    });
+
+    test('radius seed derives the full scale', () {
+      final theme = FossThemeData.light.retheme(
+        const FossThemeSpec(radius: 10),
+      );
+      expect(theme.radii, FossRadii.standard);
+    });
+
+    test('spacing seed maps straight to the unit', () {
+      final theme = FossThemeData.light.retheme(
+        const FossThemeSpec(spacing: 4.3),
+      );
+      expect(theme.spacing, const FossSpacing(unit: 4.3));
+    });
+
+    test('shadow color re-tints every layer, keeping alpha and geometry', () {
+      const tint = Color(0xFF3366FF);
+      final theme = FossThemeData.light.retheme(
+        const FossThemeSpec(shadowColor: tint),
+      );
+      const base = FossShadows.standard;
+      for (final step in [
+        (theme.shadows.xs, base.xs),
+        (theme.shadows.sm, base.sm),
+        (theme.shadows.md, base.md),
+        (theme.shadows.lg, base.lg),
+      ]) {
+        final (tinted, original) = step;
+        expect(tinted.length, original.length);
+        for (var i = 0; i < tinted.length; i++) {
+          expect(tinted[i].color.r, tint.r);
+          expect(tinted[i].color.g, tint.g);
+          expect(tinted[i].color.b, tint.b);
+          expect(tinted[i].color.a, original[i].color.a);
+          expect(tinted[i].offset, original[i].offset);
+          expect(tinted[i].blurRadius, original[i].blurRadius);
+          expect(tinted[i].spreadRadius, original[i].spreadRadius);
+        }
+      }
+    });
+
+    test('font family re-families every step, keeping metrics', () {
+      const family = 'Plus Jakarta Sans';
+      final t = FossThemeData.light
+          .retheme(const FossThemeSpec(fontFamily: family))
+          .typography;
+      const base = FossTypography.standard;
+      for (final step in [
+        (t.xs, base.xs),
+        (t.sm, base.sm),
+        (t.base, base.base),
+        (t.lg, base.lg),
+        (t.xl, base.xl),
+        (t.xl2, base.xl2),
+      ]) {
+        final (styled, original) = step;
+        expect(styled.fontFamily, family);
+        expect(styled.fontSize, original.fontSize);
+        expect(styled.height, original.height);
+        expect(styled.letterSpacing, original.letterSpacing);
+      }
+    });
+  });
+
+  group('FossRadii.fromBase', () {
+    test('base 10 reproduces the standard scale', () {
+      expect(FossRadii.fromBase(10), FossRadii.standard);
+    });
+
+    test('offsets each step from the base', () {
+      final r = FossRadii.fromBase(22);
+      expect((r.sm, r.md, r.lg, r.xl, r.xl2), (18.0, 20.0, 22.0, 26.0, 28.0));
+    });
+
+    test('clamps negative steps at 0', () {
+      final r = FossRadii.fromBase(2);
+      expect((r.sm, r.md, r.lg, r.xl, r.xl2), (0.0, 0.0, 2.0, 6.0, 8.0));
+    });
+  });
+}


### PR DESCRIPTION
retheme layers a flat FossThemeSpec (enumerated color roles, plus radius, spacing, shadow-tint, and font-family seeds) over a base theme. Add FossRadii.fromBase to derive the radius scale from one value.