### PR TITLE
fix(example): replace archived lucide icons package

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:fossui/fossui.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_lite/lucide_icons_lite.dart';
 
 void main() => runApp(const ExampleApp());
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
     sdk: flutter
   fossui:
     path: ../
-  lucide_icons: ^0.257.0
+  lucide_icons_lite: ^1.41.0


### PR DESCRIPTION
## Summary

- Replace the archived `lucide_icons` dependency in the example with `lucide_icons_lite`.
- Update the import while preserving the existing `LucideIcons.*` calls.

## Why

The example does not compile with Flutter 3.47.2 because `lucide_icons` extends `IconData`, which is now a final class.
The example uses 14 `LucideIcons` identifiers, and `lucide_icons_lite` 1.41.0 provides all of them.
The replacement constructs `IconData` values directly and follows current `lucide-static` releases.

## Verification

- `flutter analyze` in `example/`: no issues found.
- `flutter build bundle` in `example/`: completed successfully.
- The generated `FontManifest.json` contains `packages/lucide_icons_lite/Lucide`.

The repository-wide `flutter analyze --fatal-infos` command reports 15 unrelated `unnecessary_unawaited` diagnostics with my local Flutter 3.47.2 SDK.
The repository CI pins Flutter 3.41.9 and remains the authoritative full-project check.

## Disclosure

I maintain `lucide_icons_lite`.
This PR is limited to the example that currently depends on the archived package.
